### PR TITLE
fix lookback position limit

### DIFF
--- a/css-in-js-mode.el
+++ b/css-in-js-mode.el
@@ -320,7 +320,7 @@ Returns a cons cell (start . end) of buffer locations."
     (let ((property
            (and (looking-back
                  "\\([[:alnum:]-]+\\):.*"
-                 (car (css-in-js-mode--current-region))
+                 (min (point) (car (css-in-js-mode--current-region)))
                  t)
                 (member (match-string-no-properties 1)
                         css-property-ids))))


### PR DESCRIPTION
if the current CSS-in-JS region is edited in a way which causes the grammar to report syntax errors then `css-in-js-mode--current-region` could detect a region which is after `point` in the buffer (which causes `looking-back` to throw an error)